### PR TITLE
Add translation mechanism for CTM invokation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pacta-data/
+working_dir/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ COPY DESCRIPTION /DESCRIPTION
 #   pak::pak(c(gh_pkgs, workflow_pkgs)); \
 #   "
 
-COPY . /
+COPY bound/ /bound/
+COPY default_config.json /default_config.json
 
 # set default run behavior
 ENTRYPOINT [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# using rocker r-vers as a base with R 4.3.1
+# https://hub.docker.com/r/rocker/r-ver
+# https://rocker-project.org/images/versioned/r-ver.html
+#
+# sets CRAN repo to use Posit Package Manager to freeze R package versions to
+# those available on 2023-10-30
+# https://packagemanager.posit.co/client/#/repos/2/overview
+# https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30
+
+# set proper base image
+ARG R_VERS="4.3.1"
+FROM ghcr.io/rmi-pacta/workflow.pacta.report:pr2 AS base
+
+# set Docker image labels
+LABEL org.opencontainers.image.source=https://github.com/RMI-PACTA/poc.workflow.pacta.ctm
+LABEL org.opencontainers.image.description="Docker image to run PACTA"
+LABEL org.opencontainers.image.licenses=MIT
+LABEL org.opencontainers.image.title=""
+LABEL org.opencontainers.image.revision=""
+LABEL org.opencontainers.image.version=""
+LABEL org.opencontainers.image.vendor=""
+LABEL org.opencontainers.image.base.name=""
+LABEL org.opencontainers.image.ref.name=""
+LABEL org.opencontainers.image.authors=""
+
+# set apt-get to noninteractive mode
+ARG DEBIAN_FRONTEND="noninteractive"
+ARG DEBCONF_NOWARNINGS="yes"
+
+# # install system dependencies
+# RUN apt-get update \
+#     && apt-get install -y --no-install-recommends \
+#       libpng-dev=1.6.* \
+#       libxt6=1:1.2.* \
+#       pandoc=2.9.* \
+#     && chmod -R a+rwX /root \
+#     && rm -rf /var/lib/apt/lists/*
+
+# # set frozen CRAN repo
+# ARG CRAN_REPO="https://packagemanager.posit.co/cran/__linux__/jammy/2023-10-30"
+# RUN echo "options(repos = c(CRAN = '$CRAN_REPO'), pkg.sysreqs = FALSE)" >> "${R_HOME}/etc/Rprofile.site" \
+#       # install packages for dependency resolution and installation
+#       && Rscript -e "install.packages('pak'); pak::pkg_install('renv')"
+COPY pacta-data /pacta-data
+
+FROM base AS install-pacta
+
+# copy in everything from this repo
+COPY DESCRIPTION /DESCRIPTION
+
+# # PACTA R package tags
+# ARG report_tag="/tree/main"
+# ARG summary_tag="/tree/main"
+# ARG utils_tag="/tree/main"
+
+# ARG report_url="https://github.com/rmi-pacta/pacta.portfolio.report"
+# ARG summary_url="https://github.com/rmi-pacta/pacta.executive.summary"
+# ARG utils_url="https://github.com/rmi-pacta/pacta.portfolio.utils"
+
+# # install R package dependencies
+# RUN Rscript -e "\
+#   gh_pkgs <- \
+#     c( \
+#       paste0('$report_url', '$report_tag'), \
+#       paste0('$summary_url', '$summary_tag'), \
+#       paste0('$utils_url', '$utils_tag') \
+#     ); \
+#   workflow_pkgs <- renv::dependencies('DESCRIPTION')[['Package']]; \
+#   workflow_pkgs <- grep('^pacta[.]', workflow_pkgs, value = TRUE, invert = TRUE); \
+#   pak::pak(c(gh_pkgs, workflow_pkgs)); \
+#   "
+
+COPY . /
+
+# set default run behavior
+ENTRYPOINT [""]
+CMD ["sh"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@
 **This repo is a Proof of concept**.
 
 This repo defines a Dockerfile and translation code to extend `workflow.pacta.report` to match the invokation logic for `workflow.transition.monitor`, in hopes that we can support a single docker stack.
+
+```sh
+
+docker build . -t fakectm
+
+docker run -it --rm \
+  --network none \
+  --platform linux/amd64 \
+  --env LOG_LEVEL=TRACE \
+  --mount type=bind,source=./working_dir,target=/bound/working_dir \
+  fakectm /bound/bin/run-r-scripts "1234"
+
+
+```
+  --mount type=bind,readonly,source=${data_dir},target=/pacta-data \

--- a/bound/bin/run-r-scripts
+++ b/bound/bin/run-r-scripts
@@ -5,9 +5,9 @@ umask 000
 
 # R --args "$1"
 Rscript --vanilla /bound/ctm_translation.R "${1:-1234}" && \
-  Rscript --vanilla pacta_01.R "/bound/working_dir/params.json" && \
-  Rscript --vanilla pacta_02.R "/bound/working_dir/params.json" && \
-  Rscript --vanilla pacta_03.R "/bound/working_dir/params.json" && \
+  Rscript --vanilla /pacta_01.R "/bound/working_dir/params.json" && \
+  Rscript --vanilla /pacta_02.R "/bound/working_dir/params.json" && \
+  Rscript --vanilla /pacta_03.R "/bound/working_dir/params.json" && \
   cp -r /bound/working_dir/40_Results/report /bound/working_dir/50_Outputs && \
   cp -r /bound/working_dir/40_Results/executive_summary /bound/working_dir/50_Outputs && \
   echo "Done!"

--- a/bound/bin/run-r-scripts
+++ b/bound/bin/run-r-scripts
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+# Set permissions so that new files can be deleted/overwritten outside docker
+umask 000
+
+# R --args "$1"
+Rscript --vanilla /bound/ctm_translation.R "${1:-1234}" && \
+  Rscript --vanilla pacta_01.R "/bound/working_dir/params.json" && \
+  Rscript --vanilla pacta_02.R "/bound/working_dir/params.json" && \
+  Rscript --vanilla pacta_03.R "/bound/working_dir/params.json" && \
+  cp -r /bound/working_dir/40_Results/report /bound/working_dir/50_Outputs && \
+  cp -r /bound/working_dir/40_Results/executive_summary /bound/working_dir/50_Outputs && \
+  echo "Done!"
+
+  # && R --args "/bound/working_dir/params.json"

--- a/bound/ctm_translation.R
+++ b/bound/ctm_translation.R
@@ -1,0 +1,46 @@
+portfolio_name <- commandArgs(trailingOnly = TRUE)
+
+working_dir <- file.path("/", "bound", "working_dir")
+
+params_file <- file.path(
+  working_dir,
+  "10_Parameter_File",
+  paste0(portfolio_name, "_PortfolioParameters.yml")
+)
+portfolio_file <- file.path(
+  working_dir,
+  "20_Raw_Inputs",
+  paste0(portfolio_name, ".csv")
+)
+
+if (file.exists(params_file)) {
+  raw_portfolio_params <- config::get(file = params_file)[["parameters"]]
+} else {
+  logger::log_error("Parameter file not found")
+  stop("Parameter file not found")
+}
+
+imported_params <- raw_portfolio_params
+imported_params[["language_select"]] <- imported_params[["language"]]
+
+default_params <- jsonlite::fromJSON("/default_config.json")
+
+params <- config::merge(default_params, raw_portfolio_params)
+
+if (params[["holdings_date"]] == "2022Q4") {
+  params[["data_dir"]] <- file.path("/", "pacta-data", params[["holdings_date"]])
+} else {
+  stop("This demo only supports 2022Q4 holdings_date")
+}
+
+if (params[["project_code"]] != "GENERAL") {
+  stop("This demo only supports GENERAL project_code")
+}
+
+params[["portfolio_path"]] <- portfolio_file
+params[["output_dir"]] <- file.path(working_dir, "40_Results")
+
+writeLines(
+  jsonlite::toJSON(params, pretty = TRUE, auto_unbox = TRUE),
+  con = file.path(working_dir, "params.json")
+)

--- a/bound/ctm_translation.R
+++ b/bound/ctm_translation.R
@@ -1,3 +1,4 @@
+logger::log_info("Translating params to CTM format")
 portfolio_name <- commandArgs(trailingOnly = TRUE)
 
 working_dir <- file.path("/", "bound", "working_dir")
@@ -13,6 +14,7 @@ portfolio_file <- file.path(
   paste0(portfolio_name, ".csv")
 )
 
+logger::log_info("Reading portfolio parameters")
 if (file.exists(params_file)) {
   raw_portfolio_params <- config::get(file = params_file)[["parameters"]]
 } else {
@@ -25,6 +27,7 @@ imported_params[["language_select"]] <- imported_params[["language"]]
 
 default_params <- jsonlite::fromJSON("/default_config.json")
 
+logger::log_info("Merging default and imported parameters")
 params <- config::merge(default_params, raw_portfolio_params)
 
 if (params[["holdings_date"]] == "2022Q4") {
@@ -40,7 +43,9 @@ if (params[["project_code"]] != "GENERAL") {
 params[["portfolio_path"]] <- portfolio_file
 params[["output_dir"]] <- file.path(working_dir, "40_Results")
 
+logger::log_info("Writing parameters to file")
 writeLines(
   jsonlite::toJSON(params, pretty = TRUE, auto_unbox = TRUE),
   con = file.path(working_dir, "params.json")
 )
+logger::log_info("Done translating params to CTM format")

--- a/default_config.json
+++ b/default_config.json
@@ -1,0 +1,69 @@
+{
+  "data_dir": "../pacta-data/2022Q4",
+  "portfolio_path": "input_dir/default_portfolio.csv",
+  "output_dir": "output_dir",
+  "start_year": 2022,
+  "equity_market_list": [
+    "GlobalMarket",
+    "DevelopedMarket",
+    "EmergingMarket"
+  ],
+  "scenario_sources_list": [
+    "GECO2022",
+    "IPR2021",
+    "ISF2021",
+    "WEO2022"
+  ],
+  "scenario_geographies_list": [
+    "Global",
+    "GlobalAggregate",
+    "NonOECD",
+    "OECD"
+  ],
+  "sector_list": [
+    "Power",
+    "Automotive",
+    "Oil&Gas",
+    "Coal",
+    "Steel",
+    "Aviation",
+    "Cement"
+  ],
+  "has_map": false,
+  "project_code": "GENERAL",
+  "portfolio_name": "DefaultPortfolio",
+  "investor_name": "DefaultInvestor",
+  "peer_group": "bank",
+  "language_select": "EN",
+  "user_id": "4",
+  "project_report_name": "general",
+  "display_currency": "USD",
+  "currency_exchange_value": 1,
+  "select_scenario": "WEO2022_NZE_2050",
+  "scenario_other": "GECO2022_1.5C",
+  "portfolio_allocation_method": "portfolio_weight",
+  "scenario_geography": "Global",
+  "tech_roadmap_sectors": [
+    "Power",
+    "Automotive",
+    "Oil&Gas",
+    "Coal"
+  ],
+  "pacta_sectors_not_analysed": [
+    "Steel",
+    "Aviation",
+    "Cement"
+  ],
+  "green_techs": [
+    "RenewablesCap",
+    "HydroCap",
+    "NuclearCap",
+    "Hybrid",
+    "Electric",
+    "FuelCell",
+    "Electric Arc Furnace"
+  ],
+  "user_results_path": "input_dir/user_results",
+  "real_estate_dir": "input_dir/real_estate",
+  "survey_dir": "input_dir/survey"
+}


### PR DESCRIPTION
Definitely a proof of concept

this defines a (really rough) translation layer to translate the `workflow.pacta` docker stack (via `workflow.pacta.report`, still in PR at this time) to work with the API defined by `workflow.transition.monitor` (namely run with `docker run <image_name> run-r-scripts "portfolioID"`)